### PR TITLE
Add the config step for updating the lower_case_table_names in MySQL …

### DIFF
--- a/deployment/installation-guide.md
+++ b/deployment/installation-guide.md
@@ -31,6 +31,19 @@
     ```
     mysql -u root -p
     ```
+5. [Important] Configure Table Name Consistency
+   To ensure consistent behavior of table name handling across different operating systems (especially when deploying between Windows and Linux), update the MySQL configuration to set `lower_case_table_names = 1`.
+   This setting should be added under the [mysqld] section of your MySQL configuration file (my.ini or my.cnf):
+
+   [mysqld]
+   lower_case_table_names=1
+   
+   Verify the current setting of **lower_case_table_names** in your MySQL server by running the following SQL query:
+
+   ```
+   SHOW VARIABLES LIKE 'lower_case_table_names';
+   ```
+   Note: This must be set before creating any databases or tables. Changing it afterward can cause issues with case sensitivity in table names.
 
 ***
 


### PR DESCRIPTION
## 📋 Description

JIRA ID: 

Add a step in the MySQL installation guide to configure lower_case_table_names for table name consistency across environments. Also included a query to verify the setting.

---

## ✅ Type of Change

- [ ] 📚 **Documentation** (updates to docs or readme)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the installation guide to include instructions for configuring the `lower_case_table_names` setting in MySQL, ensuring consistent table name handling across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->